### PR TITLE
Add support for PolarSSL/Mbed TLS CTR DRBG random source

### DIFF
--- a/mrblib/mrb_securerandom.rb
+++ b/mrblib/mrb_securerandom.rb
@@ -3,6 +3,12 @@ class SecureRandom
     def random_bytes(n=nil)
       n = n ? n.to_int : 16
 
+      if Module.const_defined?(:PolarSSL)
+        @@entropy ||= PolarSSL::Entropy.new
+        @@ctr_drbg ||= PolarSSL::CtrDrbg.new(@@entropy)
+        return @@ctr_drbg.random_bytes(n)
+      end
+
       begin
         File.open("/dev/urandom", 'r') {|f|
           ret = f.read(n)


### PR DESCRIPTION
This adds an optional dependency on [`mruby-polarssl`](https://github.com/luisbebop/mruby-polarssl), preferring its CTR DRBG if it is available.

This PR depends on luisbebop/mruby-polarssl/pull/17 being merged first.